### PR TITLE
Implemented atomic rename

### DIFF
--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -60,6 +60,11 @@
         "description": "True to upload temp file on every save operation of VS Code to avoid breaking a webpage when a user acceses it while the file is still being uploaded (is incomplete).",
         "default": true
       },
+      "openSsh": {
+        "type": "boolean",
+        "description": "True to enable atomic file uploads (only supported by openSSH servers). Must be used together with 'useTempFile' = true.",
+        "default": false
+      },
       "downloadOnOpen": {
         "enum": ["confirm", true, false],
         "description": "True to download when a file opens.",

--- a/src/core/fileService.ts
+++ b/src/core/fileService.ts
@@ -38,6 +38,7 @@ interface ServiceOption {
   remote?: string;
   uploadOnSave: boolean;
   useTempFile: boolean;
+  openSsh: boolean;
   downloadOnOpen: boolean | 'confirm';
   syncOption: {
     delete: boolean;

--- a/src/core/fs/fileSystem.ts
+++ b/src/core/fs/fileSystem.ts
@@ -84,6 +84,7 @@ export default abstract class FileSystem {
   abstract unlink(path: string): Promise<void>;
   abstract rmdir(path: string, recursive: boolean): Promise<void>;
   abstract rename(srcPath: string, destPath: string): Promise<void>;
+  abstract renameAtomic(srcPath: string, destPath: string): Promise<void>;
 
   static abortReadableStream(stream: Readable) {
     const err = new Error('Transfer Aborted') as FileSystemError;

--- a/src/core/fs/ftpFileSystem.ts
+++ b/src/core/fs/ftpFileSystem.ts
@@ -270,10 +270,10 @@ export default class FTPFileSystem extends RemoteFileSystem {
   }
 
   async rename(srcPath: string, destPath: string): Promise<void> {
-    return await this.atomicRenmae(srcPath, destPath);
+    return await this.renameAtomic(srcPath, destPath);
   }
 
-  private async atomicRenmae(srcPath: string, destPath: string): Promise<void> {
+  async renameAtomic(srcPath: string, destPath: string): Promise<void> {
     const task = () =>
       new Promise<void>((resolve, reject) => {
         this.ftp.rename(srcPath, destPath, err => {

--- a/src/core/fs/localFileSystem.ts
+++ b/src/core/fs/localFileSystem.ts
@@ -189,4 +189,8 @@ export default class LocalFileSystem extends FileSystem {
   rename(srcPath: string, destPath: string): Promise<void> {
     return fse.rename(srcPath, destPath);
   }
+
+  renameAtomic(srcPath: string, destPath: string): Promise<void> {
+    return fse.rename(srcPath, destPath);
+  }
 }

--- a/src/core/fs/sftpFileSystem.ts
+++ b/src/core/fs/sftpFileSystem.ts
@@ -189,6 +189,19 @@ export default class SFTPFileSystem extends RemoteFileSystem {
     });
   }
 
+  // See: https://github.com/mscdex/ssh2/issues/1054
+  renameAtomic(srcPath: string, destPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.sftp.ext_openssh_rename(srcPath, destPath, err => {
+        if (err) {
+          return reject(err);
+        }
+
+        resolve();
+      });
+    });
+  }
+
   async put(input: Readable, path, option?: FileOption): Promise<void> {
     if (option && option.fd) {
       const fd = option.fd as SFTPFileDescriptor;

--- a/src/core/transferTask.ts
+++ b/src/core/transferTask.ts
@@ -23,6 +23,7 @@ export interface TransferOption {
   fallbackMode?: number;
   perserveTargetMode: boolean;
   useTempFile?: boolean;
+  openSsh?: boolean;
 }
 
 export default class TransferTask implements Task {
@@ -117,6 +118,7 @@ export default class TransferTask implements Task {
     const {
       perserveTargetMode,
       useTempFile,
+      openSsh,
       fallbackMode,
       atime,
       mtime,
@@ -191,13 +193,18 @@ export default class TransferTask implements Task {
         }
       }
 
-      if (useTempFile) {
-        // logger.info("moving from: " + target + ".new" + " to: " + target);
-        logger.info("moving from: " + uploadTarget + " to: " + target);
-        await targetFs.unlink(target);
-        await targetFs.rename(uploadTarget, target);
-      } else {
+      if(useTempFile) {
         logger.info("moving to: " + target);
+        if(openSsh) {
+          await targetFs.renameAtomic(uploadTarget, target);
+        } else {
+          try {
+            await targetFs.unlink(target);
+          } catch(error) {
+            // Just ignore
+          }
+          await targetFs.rename(uploadTarget, target);
+        }
       }
 
     } finally {

--- a/src/fileHandlers/transfer/index.ts
+++ b/src/fileHandlers/transfer/index.ts
@@ -64,6 +64,7 @@ export const sync2Remote = createFileHandler<SyncOption>({
     return {
       perserveTargetMode: config.protocol === 'sftp',
       useTempFile: config.useTempFile,
+      openSsh: config.openSsh,
       // remoteTimeOffsetInHours: config.remoteTimeOffsetInHours,
       ignore: config.ignore,
       delete: syncOption.delete,
@@ -120,6 +121,7 @@ export const upload = createFileHandler<TransferOption>({
     return {
       perserveTargetMode: config.protocol === 'sftp',
       useTempFile: config.useTempFile,
+      openSsh: config.openSsh,
       // remoteTimeOffsetInHours: config.remoteTimeOffsetInHours,
       ignore: config.ignore,
     };
@@ -137,6 +139,7 @@ export const uploadFile = createFileHandler<TransferOption>({
     return {
       perserveTargetMode: config.protocol === 'sftp',
       useTempFile: config.useTempFile,
+      openSsh: config.openSsh,
       // remoteTimeOffsetInHours: config.remoteTimeOffsetInHours,
       ignore: config.ignore,
     };
@@ -154,6 +157,7 @@ export const uploadFolder = createFileHandler<TransferOption>({
     return {
       perserveTargetMode: config.protocol === 'sftp',
       useTempFile: config.useTempFile,
+      openSsh: config.openSsh,
       // remoteTimeOffsetInHours: config.remoteTimeOffsetInHours,
       ignore: config.ignore,
     };

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -35,6 +35,7 @@ const configScheme = {
   remotePath: Joi.string().required(),
   uploadOnSave: Joi.boolean(),
   useTempFile: Joi.boolean(),
+  openSsh: Joi.boolean(),
   downloadOnOpen: Joi.boolean().allow('confirm'),
 
   ignore: Joi.array()
@@ -69,6 +70,7 @@ const defaultConfig = {
   remotePath: './',
   uploadOnSave: false,
   useTempFile: true,
+  openSsh: false,
   downloadOnOpen: false,
   ignore: [],
   // ignoreFile: undefined,
@@ -178,6 +180,7 @@ export function newConfig(basePath) {
             remotePath: '/',
             uploadOnSave: true,
             useTempFile: true,
+            openSsh: false,
           },
           { spaces: 4 }
         )


### PR DESCRIPTION
* Added "openSsh" option to use "ext_openssh_rename()" which is atomic, while normal unlink() + rename() is not atomic. See: https://github.com/mscdex/ssh2/issues/1054
* Added renameAtomic() functions
* Renamed misspelled atomicRenmae() function