### PR TITLE
Fix ssh config resolution

### DIFF
--- a/src/core/fileService.ts
+++ b/src/core/fileService.ts
@@ -233,36 +233,30 @@ function mergeConfigWithExternalRefer(
   }
 
   const parsedSSHConfig = sshConfig.parse(sshConfigContent);
-  const section = parsedSSHConfig.find({
-    Host: copyed.host,
-  });
-
-  if (section === null) {
-    return copyed;
-  }
+  const computed = parsedSSHConfig.compute(copyed.host);
 
   const mapping = new Map([
     ['hostname', 'host'],
     ['port', 'port'],
     ['user', 'username'],
-    ['identityfile', 'privateKeyPath'],
     ['serveraliveinterval', 'keepalive'],
     ['connecttimeout', 'connTimeout'],
   ]);
 
-  section.config.forEach(line => {
-    if (!line.param) {
+  Object.entries<any>(computed).forEach(([param, value]) => {
+    if (param.toLowerCase() === 'identityfile') {
+      setConfigValue(copyed, 'privateKeyPath', value[0]);
       return;
     }
 
-    const key = mapping.get(line.param.toLowerCase());
+    const key = mapping.get(param.toLowerCase());
 
     if (key !== undefined) {
       // don't need consider config priority, always set to the resolve host.
       if (key === 'host') {
-        copyed[key] = line.value;
+        copyed[key] = value;
       } else {
-        setConfigValue(copyed, key, line.value);
+        setConfigValue(copyed, key, value);
       }
     }
   });


### PR DESCRIPTION
Fixes ssh config resolution.

When resolving ssh config, `ssh-config`'s `.find` method is currently used. However from `ssh-config`'s documentation:

> NOTICE: [.find] is provided to find the corresponding section in the parsed config for config manipulation. It is NOT intended to compute config of certain Host. For latter case, use .compute(host) instead.

This PR changes ssh config resolution to use `.compute` instead as suggested.

----

In particular, this allow this extension to handle:

```
# Blocks with multiple hosts
Host test-a test-b
    HostName 127.0.0.1

# Multiple blocks
Host test-c
    HostName 127.0.0.2
Host test-c
    Port 23

# Wildcards
Host test-*
    HostName 127.0.0.3
```

----

Unfortunately, `ssh2` does not support attempting multiple private keys OOTB, so I matched the current behavior of only using the first key.