### PR TITLE
Update mtime after file was saved before upload

### DIFF
--- a/src/fileHandlers/transfer/transfer.ts
+++ b/src/fileHandlers/transfer/transfer.ts
@@ -156,6 +156,9 @@ async function transferWithType(
         const document = textDocuments.find(doc => doc.fileName === config.srcFsPath);
         if (document && !document.isClosed && document.isDirty) {
           await document.save();
+          // Update mtime after file was saved
+          const stat = await config.srcFs.lstat(config.srcFsPath);
+          config.transferOption.mtime = stat.mtime;
           logger.info('save before upload.');
         }
       }


### PR DESCRIPTION
This PR fixes issue with incorrect modification time of unsaved files uploaded using "Upload Active File" command.
@Natizyskunk please add `hacktoberfest-accepted` label to this PR, I want to participate in the Hacktoberfest event. See https://hacktoberfest.digitalocean.com/resources/participation for details.