### PR TITLE
Add support for OpenSSH v8.8 SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.15.13 - 2022-02-11
+* Add support for OpenSSH v8.8 SSH private key by using SHA-2 instead of SHA-1 to fix SSH public key signatures. (See issue [#112](https://github.com/Natizyskunk/vscode-sftp/issues/112)).
+
 ## 1.15.12 - 2022-02-11
 * Add deletions support to "Upload Changed files" command. (Pull request [#113](https://github.com/Natizyskunk/vscode-sftp/pull/113) from @brykov vscode-sftp:master merged inside [#117](https://github.com/Natizyskunk/vscode-sftp/pull/117)).
 
@@ -45,7 +48,7 @@
 
 ## 1.15.1 - 2021-08-24
   * Add the `useTempFile` option to the test config spec.
-  * Fix get target mode error && add more precise logger-infos for tranfer tasks  (Merged pull request [#29](https://github.com/Natizyskunk/vscode-sftp/pull/29) from @kripper vscode-sftp:master).
+  * Fix get target mode error && add more precise logger-infos for tranfer tasks (Merged pull request [#29](https://github.com/Natizyskunk/vscode-sftp/pull/29) from @kripper vscode-sftp:master).
 
 ## 1.15.0 - 2021-08-23
   * New option [useTempFile](https://github.com/Natizyskunk/vscode-sftp/wiki/Common-Config#usetempfile) (Merged pull request [#29](https://github.com/Natizyskunk/vscode-sftp/pull/29) from @kripper vscode-sftp:master).

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,9 +1,9 @@
 - [Error: Failure](#error-failure)
-	- [Error: Failure - Solution One](#error-failure---solution-one)
-	- [Error: Failure - Solution Two](#error-failure---solution-two)
+  - [Error: Failure - Solution One](#error-failure---solution-one)
+  - [Error: Failure - Solution Two](#error-failure---solution-two)
 - [Error: Connection closed](#error-connection-closed)
 - [ENFILE: file table overflow ...](#enfile-file-table-overflow-)
-	- [ENFILE: file table overflow ... - Solution for MacOS harsh limit](#enfile-file-table-overflow----solution-for-macos-harsh-limit)
+  - [ENFILE: file table overflow ... - Solution for MacOS harsh limit](#enfile-file-table-overflow----solution-for-macos-harsh-limit)
 - [How do I upload content inside a folder, but not the folder itself?](#how-do-i-upload-content-inside-a-folder-but-not-the-folder-itself)
 - [Clicking Upload Changed Files does not work](#clicking-upload-changed-files-does-not-work)
 - [How can I upload files as root?](#how-can-i-upload-files-as-root)
@@ -31,9 +31,6 @@ The problem would be that the SFTP extension keeps closing the connection for th
 You'll have to Explicitly override the default transport layer algorithms used for the connection to remove the new `"diffie-hellman-group-exchange-sha256"` algorithm that cause the problem from the `kex` section. Just add this in your `sftp.json` config file, which should make it work.
 ```json
 {
-	...
-	"host": "exemple.com",
-	...
 	"algorithms": {
 		"kex": [
 			"ecdh-sha2-nistp256", 
@@ -54,7 +51,11 @@ You'll have to Explicitly override the default transport layer algorithms used f
 			"ssh-rsa", 
 			"ecdsa-sha2-nistp256", 
 			"ecdsa-sha2-nistp384", 
-			"ecdsa-sha2-nistp521"
+			"ecdsa-sha2-nistp521",
+			"rsa-sha2-512",
+			"rsa-sha2-256",
+      "ssh-dss",
+      "ssh-ed25519"
 		],
 		"hmac": [
 			"hmac-sha2-256", 

--- a/docs/config.md
+++ b/docs/config.md
@@ -139,36 +139,42 @@ Note: *Requires the server to have keyboard-interactive authentication enabled.*
 Explicit overrides for the default transport layer algorithms used for the connection.
 
 **default**:
-```js
-algorithms: {
-  "kex": [
-    "ecdh-sha2-nistp256",
-    "ecdh-sha2-nistp384",
-    "ecdh-sha2-nistp521",
-    "diffie-hellman-group-exchange-sha256",
-    "diffie-hellman-group14-sha1"
-  ],
-  "cipher": [
-    "aes128-ctr",
-    "aes192-ctr",
-    "aes256-ctr",
-    "aes128-gcm",
-    "aes128-gcm@openssh.com",
-    "aes256-gcm",
-    "aes256-gcm@openssh.com"
-  ],
-  "serverHostKey": [
-    "ssh-rsa",
-    "ecdsa-sha2-nistp256",
-    "ecdsa-sha2-nistp384",
-    "ecdsa-sha2-nistp521"
-  ],
-  "hmac": [
-    "hmac-sha2-256",
-    "hmac-sha2-512",
-    "hmac-sha1"
-  ]
-},
+```json
+{
+  "algorithms": {
+    "kex": [
+      "ecdh-sha2-nistp256",
+      "ecdh-sha2-nistp384",
+      "ecdh-sha2-nistp521",
+      "diffie-hellman-group-exchange-sha256",
+      "diffie-hellman-group14-sha1"
+    ],
+    "cipher": [
+      "aes128-ctr",
+      "aes192-ctr",
+      "aes256-ctr",
+      "aes128-gcm",
+      "aes128-gcm@openssh.com",
+      "aes256-gcm",
+      "aes256-gcm@openssh.com"
+    ],
+    "serverHostKey": [
+      "ssh-rsa",
+      "ecdsa-sha2-nistp256",
+      "ecdsa-sha2-nistp384",
+      "ecdsa-sha2-nistp521",
+      "rsa-sha2-512",
+      "rsa-sha2-256",
+      "ssh-dss",
+      "ssh-ed25519"
+    ],
+    "hmac": [
+      "hmac-sha2-256",
+      "hmac-sha2-512",
+      "hmac-sha1"
+    ]
+  },
+}
 ```
 
 ### sshConfigPath

--- a/docs/sftp_config.md
+++ b/docs/sftp_config.md
@@ -24,34 +24,40 @@ Explicit overrides for the default transport layer algorithms used for the conne
 
 **Default**:
 ```json
-algorithms: {
-  "kex": [
-    "ecdh-sha2-nistp256",
-    "ecdh-sha2-nistp384",
-    "ecdh-sha2-nistp521",
-    "diffie-hellman-group-exchange-sha256",
-    "diffie-hellman-group14-sha1"
-  ],
-  "cipher": [
-    "aes128-ctr",
-    "aes192-ctr",
-    "aes256-ctr",
-    "aes128-gcm",
-    "aes128-gcm@openssh.com",
-    "aes256-gcm",
-    "aes256-gcm@openssh.com"
-  ],
-  "serverHostKey": [
-    "ssh-rsa",
-    "ecdsa-sha2-nistp256",
-    "ecdsa-sha2-nistp384",
-    "ecdsa-sha2-nistp521"
-  ],
-  "hmac": [
-    "hmac-sha2-256",
-    "hmac-sha2-512",
-    "hmac-sha1"
-  ]
+{
+  "algorithms": {
+    "kex": [
+      "ecdh-sha2-nistp256",
+      "ecdh-sha2-nistp384",
+      "ecdh-sha2-nistp521",
+      "diffie-hellman-group-exchange-sha256",
+      "diffie-hellman-group14-sha1"
+    ],
+    "cipher": [
+      "aes128-ctr",
+      "aes192-ctr",
+      "aes256-ctr",
+      "aes128-gcm",
+      "aes128-gcm@openssh.com",
+      "aes256-gcm",
+      "aes256-gcm@openssh.com"
+    ],
+    "serverHostKey": [
+      "ssh-rsa",
+      "ecdsa-sha2-nistp256",
+      "ecdsa-sha2-nistp384",
+      "ecdsa-sha2-nistp521",
+      "rsa-sha2-512",
+      "rsa-sha2-256",
+      "ssh-dss",
+      "ssh-ed25519"
+    ],
+    "hmac": [
+      "hmac-sha2-256",
+      "hmac-sha2-512",
+      "hmac-sha1"
+    ]
+  }
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sftp",
-  "version": "1.15.12",
+  "version": "1.15.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sftp",
-      "version": "1.15.12",
+      "version": "1.15.13",
       "license": "MIT",
       "dependencies": {
         "async": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sftp",
   "displayName": "SFTP",
   "description": "SFTP/FTP sync",
-  "version": "1.15.12",
+  "version": "1.15.13",
   "publisher": "Natizyskunk",
   "author": "Natizyskunk <natan.fourie@hotmail.fr> (https://github.com/Natizyskunk)",
   "engines": {

--- a/schema/definitions.json
+++ b/schema/definitions.json
@@ -260,7 +260,10 @@
                 "ecdsa-sha2-nistp256",
                 "ecdsa-sha2-nistp384",
                 "ecdsa-sha2-nistp521",
-                "ssh-dss"
+                "rsa-sha2-512",
+                "rsa-sha2-256",
+                "ssh-dss",
+                "ssh-ed25519"
               ]
             },
             "description": "Server host key formats. In server mode, this list must agree with the host private keys set in the hostKeys config setting."


### PR DESCRIPTION
Add support for OpenSSH v8.8 SSH private key by using SHA-2 instead of SHA-1 to fix SSH public key signatures. (See issue [#112](https://github.com/Natizyskunk/vscode-sftp/issues/112)).