### PR TITLE
Fixed commandOpenSshConnection.ts

### DIFF
--- a/src/commands/commandOpenSshConnection.ts
+++ b/src/commands/commandOpenSshConnection.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import { COMMAND_OPEN_CONNECTION_IN_TERMINAL } from '../constants';
 import { getAllFileService } from '../modules/serviceManager';
 import { ExplorerRoot } from '../modules/remoteExplorer';
-import { getUserSetting } from '../host';
 import { interpolate } from '../utils';
 import { checkCommand } from './abstract/createCommand';
 
@@ -20,17 +19,10 @@ function adaptPath(filepath) {
   if (isWindows) {
     return filepath.replace(/\\\\/g, '\\');
   }
-  
+
   // convert to unix style
   return filepath.replace(/\\\\/g, '/').replace(/\\/g, '/');
-  
-  // append with /mnt and convert c: to c
-  // return '/mnt/' + safeUnixPath.replace(/^([a-zA-Z]):/, '$1');
 }
-
-// function shouldUsePass(config) {
-//   return typeof config.password === 'string' && config.password.length > 0;
-// }
 
 function getSshCommand(
   config: { host: string; port: number; username: string },

--- a/src/commands/commandOpenSshConnection.ts
+++ b/src/commands/commandOpenSshConnection.ts
@@ -17,21 +17,15 @@ function shouldUseKey(config) {
 }
 
 function adaptPath(filepath) {
+  if (isWindows) {
+    return filepath.replace(/\\\\/g, '\\');
+  }
+  
   // convert to unix style
-  const safeUnixPath = filepath.replace(/\\\\/g, '/').replace(/\\/g, '/');
-  if (!isWindows) {
-    return safeUnixPath;
-  }
-
-  const setting = getUserSetting('terminal.integrated.shell');
-  const shell = setting.get('windows', '');
-
-  if (!shell.endsWith('wsl.exe')) {
-    return safeUnixPath;
-  }
-
+  return filepath.replace(/\\\\/g, '/').replace(/\\/g, '/');
+  
   // append with /mnt and convert c: to c
-  return '/mnt/' + safeUnixPath.replace(/^([a-zA-Z]):/, '$1');
+  // return '/mnt/' + safeUnixPath.replace(/^([a-zA-Z]):/, '$1');
 }
 
 // function shouldUsePass(config) {
@@ -40,11 +34,11 @@ function adaptPath(filepath) {
 
 function getSshCommand(
   config: { host: string; port: number; username: string },
-  extraOpiton?: string
+  extraOption?: string
 ) {
   let sshStr = `ssh -t ${config.username}@${config.host} -p ${config.port}`;
-  if (extraOpiton) {
-    sshStr += ` ${extraOpiton}`;
+  if (extraOption) {
+    sshStr += ` ${extraOption}`;
   }
   // sshStr += ` "cd \\"${config.workingDir}\\"; exec \\$SHELL -l"`;
   return sshStr;


### PR DESCRIPTION
1. Fixed incorrect option name
extraOpiton -> extraOption

2. "Open SSH in Terminal" not working because "terminal.integrated.shell.windows" is deprecated

> This is deprecated, the new recommended way to configure your default shell is by creating a terminal profile in #terminal.integrated.profiles.windows# and setting its profile name as the default in #terminal.integrated.defaultProfile.windows#.
> ref: https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-profiles

3. /mnt/c/ path for windows work only WSL installed.