### PR TITLE
Fixed not refreshed when create file or folder and delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -497,7 +497,7 @@
         {
           "command": "sftp.create.folder",
           "group": "7_modification",
-          "when": "view == remoteExplorer && viewItem != folder"
+          "when": "view == remoteExplorer && viewItem != file"
         },
         {
           "command": "sftp.create.file",

--- a/src/commands/fileCommandRevealInRemoteExplorer.ts
+++ b/src/commands/fileCommandRevealInRemoteExplorer.ts
@@ -9,7 +9,6 @@ export default checkFileCommand({
   getFileTarget: uriFromExplorerContextOrEditorContext,
 
   async handleFile({ target }) {
-    // todo: make this to a method of remoteExplorer
     await app.remoteExplorer.reveal({
       resource: UResource.makeResource(target.remoteUri),
       isDirectory: false,

--- a/src/fileHandlers/create.ts
+++ b/src/fileHandlers/create.ts
@@ -38,7 +38,7 @@ export const createRemoteFile = createFileHandler<FileHandleOption & { skipDir?:
     };
   },
   afterHandle() {
-    refreshRemoteExplorer(this.target, true);
+    refreshRemoteExplorer(this.target, false);
   },
 });
 
@@ -77,6 +77,6 @@ export const createRemoteFolder = createFileHandler<FileHandleOption & { skipDir
     };
   },
   afterHandle() {
-    refreshRemoteExplorer(this.target, true);
+    refreshRemoteExplorer(this.target, false);
   },
 });

--- a/src/fileHandlers/remove.ts
+++ b/src/fileHandlers/remove.ts
@@ -1,3 +1,4 @@
+import { refreshRemoteExplorer } from './shared';
 import { fileOperations, FileType } from '../core';
 import createFileHandler from './createFileHandler';
 import { FileHandleOption } from './option';
@@ -32,5 +33,8 @@ export const removeRemote = createFileHandler<FileHandleOption & { skipDir?: boo
     return {
       ignore: config.ignore,
     };
+  },
+  afterHandle() {
+    refreshRemoteExplorer(this.target, false);
   },
 });

--- a/src/modules/remoteExplorer/treeDataProvider.ts
+++ b/src/modules/remoteExplorer/treeDataProvider.ts
@@ -67,6 +67,8 @@ export default class RemoteTreeData
   implements vscode.TreeDataProvider<ExplorerItem>, vscode.TextDocumentContentProvider {
   private _roots: ExplorerRoot[] | null;
   private _rootsMap: Map<Id, ExplorerRoot> | null;
+  private _map: Map<vscode.Uri['query'], ExplorerItem>;
+
   private _onDidChangeFolder: vscode.EventEmitter<ExplorerItem> = new vscode.EventEmitter<
     ExplorerItem
   >();
@@ -74,7 +76,6 @@ export default class RemoteTreeData
   readonly onDidChangeTreeData: vscode.Event<ExplorerItem> = this._onDidChangeFolder.event;
   readonly onDidChange: vscode.Event<vscode.Uri> = this._onDidChangeFile.event;
 
-  // FIXME: refresh can't work for user created ExplorerItem
   async refresh(item?: ExplorerItem): Promise<any> {
     // refresh root
     if (!item) {
@@ -95,6 +96,10 @@ export default class RemoteTreeData
         .filter(i => !i.isDirectory)
         .forEach(i => this._onDidChangeFile.fire(makePreivewUrl(i.resource.uri)));
     } else {
+      const parent = await this.getParent(item);
+      if (parent) {
+        this._onDidChangeFolder.fire(parent);
+      }
       this._onDidChangeFile.fire(makePreivewUrl(item.resource.uri));
     }
   }
@@ -153,18 +158,27 @@ export default class RemoteTreeData
       .filter(filterFile)
       .map(file => {
         const isDirectory = file.type === FileType.Directory;
-
-        return {
-          resource: UResource.updateResource(item.resource, {
-            remotePath: file.fspath,
-          }),
-          isDirectory,
-        };
+        const newResource = UResource.updateResource(item.resource, {
+          remotePath: file.fspath,
+        });
+        const mapItem = this._map.get(newResource.uri.query);
+        if (mapItem) {
+          return mapItem;
+        } else {
+          const newItem = {
+            resource: UResource.updateResource(item.resource, {
+              remotePath: file.fspath,
+            }),
+            isDirectory,
+          };
+          this._map.set(newItem.resource.uri.query, newItem);
+          return newItem;
+        }
       })
       .sort(dirFirstSort);
   }
 
-  getParent(item: ExplorerChild): ExplorerItem | null {
+  async getParent(item: ExplorerChild): Promise<ExplorerItem> {
     const resourceUri = item.resource.uri;
     const root = this.findRoot(resourceUri);
     if (!root) {
@@ -172,15 +186,25 @@ export default class RemoteTreeData
     }
 
     if (item.resource.fsPath === root.resource.fsPath) {
-      return null;
+      return root;
     }
 
-    return {
-      resource: UResource.updateResource(item.resource, {
-        remotePath: upath.dirname(item.resource.fsPath),
-      }),
-      isDirectory: true,
-    };
+    const fspath = upath.dirname(item.resource.fsPath);
+    const newResource = UResource.updateResource(item.resource, {
+      remotePath: fspath,
+    });
+    const mapItem = this._map.get(newResource.uri.query);
+    if (mapItem) {
+      return mapItem;
+    } else {
+      const newMapItem = {
+        resource: newResource,
+        isDirectory: true,
+      };
+      this._map.set(newResource.uri.query, newMapItem);
+      await this.getChildren(newMapItem);
+      return newMapItem;
+    }
   }
 
   findRoot(uri: vscode.Uri): ExplorerRoot | null | undefined {
@@ -222,6 +246,7 @@ export default class RemoteTreeData
 
     this._roots = [];
     this._rootsMap = new Map();
+    this._map = new Map();
     getAllFileService().forEach(fileService => {
       const config = fileService.getConfig();
       const id = fileService.id;
@@ -243,6 +268,7 @@ export default class RemoteTreeData
       };
       this._roots!.push(item);
       this._rootsMap!.set(id, item);
+      this._map.set(item.resource.uri.query, item);
     });
     return this._roots;
   }


### PR DESCRIPTION
Fixed:
- Remote Explorer Not refreshed when create file or folder and delete.
- "Create Folder" is not visible when right-clicking on a Remote Explorer folder.
- "Create Folder" is visible when right-clicking on a Remote Explorer file.
- "Reveal in Remote Explorer" not working.
- Refresh Button not work when file is selected
  - before
![Honeycam 2022-10-04 11-15-32](https://user-images.githubusercontent.com/1353557/193720237-f28bccb7-bae2-4158-aa62-b8d131cf5e3d.gif)
  - after
![Honeycam 2022-10-04 11-12-57](https://user-images.githubusercontent.com/1353557/193720379-4f52b856-36f3-4dcb-b1bb-0d5f9b8c4ec5.gif)

Fix #47, Fix #122, Fix #134, Fix #212, Fix #133