### PR TITLE
Feat: Upload to all profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,36 @@
         "category": "SFTP"
       },
       {
+        "command": "sftp.upload.file.to.allProfiles",
+        "title": "Upload File To All Profiles",
+        "category": "SFTP"
+      },
+      {
+        "command": "sftp.upload.activeFile.to.allProfiles",
+        "title": "Upload Active File To All Profiles",
+        "category": "SFTP"
+      },
+      {
+        "command": "sftp.upload.folder.to.allProfiles",
+        "title": "Upload Folder To All Profiles",
+        "category": "SFTP"
+      },
+      {
+        "command": "sftp.upload.activeFolder.to.allProfiles",
+        "title": "Upload Active Folder To All Profiles",
+        "category": "SFTP"
+      },
+      {
+        "command": "sftp.upload.project.to.allProfiles",
+        "title": "Upload Project To All Profiles",
+        "category": "SFTP"
+      },
+      {
+        "command": "sftp.forceUpload.to.allProfiles",
+        "title": "Force Upload To All Profiles",
+        "category": "SFTP"
+      },
+      {
         "command": "sftp.download.file",
         "title": "Download File",
         "category": "SFTP"
@@ -274,6 +304,18 @@
           "when": "sftp.enabled"
         },
         {
+          "command": "sftp.upload.activeFile.to.allProfiles",
+          "when": "sftp.enabled"
+        },
+        {
+          "command": "sftp.upload.activeFolder.to.allProfiles",
+          "when": "sftp.enabled"
+        },
+        {
+          "command": "sftp.upload.project.to.allProfiles",
+          "when": "sftp.enabled"
+        },
+        {
           "command": "sftp.download.activeFile",
           "when": "sftp.enabled"
         },
@@ -327,6 +369,18 @@
         },
         {
           "command": "sftp.forceUpload",
+          "when": "false"
+        },
+        {
+          "command": "sftp.upload.file.to.allProfiles",
+          "when": "false"
+        },
+        {
+          "command": "sftp.upload.folder.to.allProfiles",
+          "when": "false"
+        },
+        {
+          "command": "sftp.forceUpload.to.allProfiles",
           "when": "false"
         },
         {
@@ -416,6 +470,17 @@
           "when": "sftp.enabled && explorerResourceIsFolder"
         },
         {
+          "command": "sftp.upload.file.to.allProfiles",
+          "group": "sftp.trans@1",
+          "when": "sftp.enabled && !explorerResourceIsRoot && !explorerResourceIsFolder"
+        },
+        {
+          "command": "sftp.upload.folder.to.allProfiles",
+          "group": "sftp.trans@1",
+          "alt": "sftp.forceUpload.to.allProfiles",
+          "when": "sftp.enabled && explorerResourceIsFolder"
+        },
+        {
           "command": "sftp.download.file",
           "group": "sftp.trans@2",
           "when": "sftp.enabled && !explorerResourceIsRoot && !explorerResourceIsFolder"
@@ -430,6 +495,11 @@
       "editor/context": [
         {
           "command": "sftp.upload.file",
+          "group": "sftp.trans@1",
+          "when": "sftp.enabled && resourceScheme == file"
+        },
+        {
+          "command": "sftp.upload.file.to.allProfiles",
           "group": "sftp.trans@1",
           "when": "sftp.enabled && resourceScheme == file"
         },
@@ -497,6 +567,17 @@
         },
         {
           "command": "sftp.upload.file",
+          "group": "3_trans@1",
+          "when": "view == remoteExplorer && viewItem != root && viewItem == file"
+        },
+        {
+          "command": "sftp.upload.folder.to.allProfiles",
+          "group": "3_trans@1",
+          "alt": "sftp.forceUpload.to.allProfiles",
+          "when": "sftp.enabled && viewItem != file"
+        },
+        {
+          "command": "sftp.upload.file.to.allProfiles",
           "group": "3_trans@1",
           "when": "view == remoteExplorer && viewItem != root && viewItem == file"
         },

--- a/src/commands/fileMultiCommandUploadActiveFileToAllProfiles.ts
+++ b/src/commands/fileMultiCommandUploadActiveFileToAllProfiles.ts
@@ -1,0 +1,9 @@
+import { COMMAND_UPLOAD_ACTIVEFILE_TO_ALL_PROFILES } from '../constants';
+import { checkFileCommand } from './abstract/createCommand';
+import fileCommandUploadActiveFile from './fileCommandUploadActiveFile';
+
+
+export default checkFileCommand({
+  ...fileCommandUploadActiveFile,
+  id: COMMAND_UPLOAD_ACTIVEFILE_TO_ALL_PROFILES
+});

--- a/src/commands/fileMultiCommandUploadActiveFolderToAllProfiles.ts
+++ b/src/commands/fileMultiCommandUploadActiveFolderToAllProfiles.ts
@@ -1,0 +1,8 @@
+import { COMMAND_UPLOAD_ACTIVEFOLDER_TO_ALL_PROFILES } from '../constants';
+import { checkFileCommand } from './abstract/createCommand';
+import fileCommandUploadActiveFolder from './fileCommandUploadActiveFolder';
+
+export default checkFileCommand({
+  ...fileCommandUploadActiveFolder,
+  id: COMMAND_UPLOAD_ACTIVEFOLDER_TO_ALL_PROFILES,
+});

--- a/src/commands/fileMultiCommandUploadFileToAllProfiles.ts
+++ b/src/commands/fileMultiCommandUploadFileToAllProfiles.ts
@@ -1,0 +1,8 @@
+import { COMMAND_UPLOAD_FILE_TO_ALL_PROFILES } from '../constants';
+import { checkFileCommand } from './abstract/createCommand';
+import fileCommandUploadFile from './fileCommandUploadFile';
+
+export default checkFileCommand({
+  ...fileCommandUploadFile,
+  id: COMMAND_UPLOAD_FILE_TO_ALL_PROFILES
+});

--- a/src/commands/fileMultiCommandUploadFolderToAllProfiles.ts
+++ b/src/commands/fileMultiCommandUploadFolderToAllProfiles.ts
@@ -1,0 +1,8 @@
+import { COMMAND_UPLOAD_FOLDER_TO_ALL_PROFILES } from '../constants';
+import { checkFileCommand } from './abstract/createCommand';
+import fileCommandUploadFolder from './fileCommandUploadFolder';
+
+export default checkFileCommand({
+  ...fileCommandUploadFolder,
+  id: COMMAND_UPLOAD_FOLDER_TO_ALL_PROFILES
+});

--- a/src/commands/fileMultiCommandUploadForceToAllProfiles.ts
+++ b/src/commands/fileMultiCommandUploadForceToAllProfiles.ts
@@ -1,0 +1,8 @@
+import { COMMAND_FORCE_UPLOAD_TO_ALL_PROFILES } from '../constants';
+import { checkFileCommand } from './abstract/createCommand';
+import fileCommandUploadForce from './fileCommandUploadForce';
+
+export default checkFileCommand({
+  ...fileCommandUploadForce,
+  id: COMMAND_FORCE_UPLOAD_TO_ALL_PROFILES
+});

--- a/src/commands/fileMultiCommandUploadProjectToAllProfiles.ts
+++ b/src/commands/fileMultiCommandUploadProjectToAllProfiles.ts
@@ -1,0 +1,8 @@
+import { COMMAND_UPLOAD_PROJECT_TO_ALL_PROFILES } from '../constants';
+import { checkFileCommand } from './abstract/createCommand';
+import fileCommandUploadProject from './fileCommandUploadProject';
+
+export default checkFileCommand({
+  ...fileCommandUploadProject,
+  id: COMMAND_UPLOAD_PROJECT_TO_ALL_PROFILES
+});

--- a/src/commands/fileMultiCommandUploadToAllProfiles.ts
+++ b/src/commands/fileMultiCommandUploadToAllProfiles.ts
@@ -1,0 +1,8 @@
+import { COMMAND_UPLOAD_TO_ALL_PROFILES } from '../constants';
+import { checkFileCommand } from './abstract/createCommand';
+import fileCommandUpload from './fileCommandUpload';
+
+export default checkFileCommand({
+  ...fileCommandUpload,
+  id: COMMAND_UPLOAD_TO_ALL_PROFILES
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,15 @@ export const COMMAND_UPLOAD_ACTIVEFILE = 'sftp.upload.activeFile';
 export const COMMAND_UPLOAD_FOLDER = 'sftp.upload.folder';
 export const COMMAND_UPLOAD_ACTIVEFOLDER = 'sftp.upload.activeFolder';
 export const COMMAND_UPLOAD_PROJECT = 'sftp.upload.project';
+
+export const COMMAND_FORCE_UPLOAD_TO_ALL_PROFILES = 'sftp.forceUpload.to.allProfiles';
+export const COMMAND_UPLOAD_TO_ALL_PROFILES = 'sftp.upload.to.allProfiles';
+export const COMMAND_UPLOAD_FILE_TO_ALL_PROFILES = 'sftp.upload.file.to.allProfiles';
+export const COMMAND_UPLOAD_ACTIVEFILE_TO_ALL_PROFILES = 'sftp.upload.activeFile.to.allProfiles';
+export const COMMAND_UPLOAD_FOLDER_TO_ALL_PROFILES = 'sftp.upload.folder.to.allProfiles';
+export const COMMAND_UPLOAD_ACTIVEFOLDER_TO_ALL_PROFILES = 'sftp.upload.activeFolder.to.allProfiles';
+export const COMMAND_UPLOAD_PROJECT_TO_ALL_PROFILES = 'sftp.upload.project.to.allProfiles';
+
 export const COMMAND_FORCE_DOWNLOAD = 'sftp.forceDownload';
 export const COMMAND_DOWNLOAD = 'sftp.download';
 export const COMMAND_DOWNLOAD_FILE = 'sftp.download.file';

--- a/src/core/fileService.ts
+++ b/src/core/fileService.ts
@@ -517,16 +517,16 @@ export default class FileService {
     return createRemoteIfNoneExist(getHostInfo(config));
   }
 
-  getConfig(): ServiceConfig {
+  getConfig(useProfile = app.state.profile): ServiceConfig {
     let config = this._config;
     const hasProfile =
       config.profiles && Object.keys(config.profiles).length > 0;
-    if (hasProfile && app.state.profile) {
-      logger.info(`Using profile: ${app.state.profile}`);
-      const profile = config.profiles![app.state.profile];
+    if (hasProfile && useProfile) {
+      logger.info(`Using profile: ${useProfile}`);
+      const profile = config.profiles![useProfile];
       if (!profile) {
         throw new Error(
-          `Unkown Profile "${app.state.profile}".` +
+          `Unkown Profile "${useProfile}".` +
             ' Please check your profile setting.' +
             ' You can set a profile by running command `SFTP: Set Profile`.'
         );
@@ -547,6 +547,11 @@ export default class FileService {
     }
 
     return this._resolveServiceConfig(completeConfig);
+  }
+
+  getAllConfig(): Array<ServiceConfig> {
+    const profiles = this._config.profiles;
+    return profiles ? Object.keys(profiles).map(p => this.getConfig(p)) : [];
   }
 
   dispose() {

--- a/src/fileHandlers/createFileHandler.ts
+++ b/src/fileHandlers/createFileHandler.ts
@@ -52,6 +52,37 @@ export function handleCtxFromUri(uri: Uri): FileHandlerContext {
   };
 }
 
+export function allHandleCtxFromUri(uri: Uri): Array<FileHandlerContext> {
+  const fileService = getFileService(uri);
+  if (!fileService) {
+    if (uri.toString(true) == "file:///${command:sftp.sync.remoteToLocal}") {
+      throw '';
+    } else {
+      throw new Error(`Config Not Found. (${uri.toString(true)})`);
+    }
+  }
+
+  const configArr = fileService.getAllConfig();
+
+  return configArr.map(config => {
+    const target = UResource.from(uri, {
+      localBasePath: fileService.baseDir,
+      remoteBasePath: config.remotePath,
+      remoteId: fileService.id,
+      remote: {
+        host: config.host,
+        port: config.port,
+      },
+    });
+
+    return {
+      fileService,
+      config,
+      target,
+    };
+  })
+}
+
 export default function createFileHandler<T>(
   handlerOption: FileHandlerOption<T>
 ): (ctx: FileHandlerContext | Uri, option?: Partial<T>) => Promise<void> {

--- a/src/fileHandlers/index.ts
+++ b/src/fileHandlers/index.ts
@@ -3,4 +3,4 @@ export * from './remove';
 export * from './diff';
 export * from './rename';
 export * from './create';
-export { handleCtxFromUri, FileHandlerContext } from './createFileHandler';
+export { handleCtxFromUri, allHandleCtxFromUri, FileHandlerContext } from './createFileHandler';

--- a/src/initCommands.ts
+++ b/src/initCommands.ts
@@ -2,7 +2,7 @@ import { ExtensionContext } from 'vscode';
 import logger from './logger';
 import { registerCommand } from './host';
 import Command from './commands/abstract/command';
-import { createCommand, createFileCommand } from './commands/abstract/createCommand';
+import { createCommand, createFileCommand, createFileMultiCommand } from './commands/abstract/createCommand';
 
 export default function init(context: ExtensionContext) {
   loadCommands(
@@ -29,6 +29,19 @@ export default function init(context: ExtensionContext) {
     ),
     /fileCommand(.*)/,
     createFileCommand,
+    context
+  );
+  loadCommands(
+    require.context(
+      // Look for files in the current directory
+      './commands',
+      // Do not look in subdirectories
+      false,
+      // Only include "_base-" prefixed .vue files
+      /fileMultiCommand.*.ts$/
+    ),
+    /fileMultiCommand(.*)/,
+    createFileMultiCommand,
     context
   );
 }


### PR DESCRIPTION
Add file upload commands able to all profiles at once.

## issues

- [希望多重上下文批量同步支持 #125](https://github.com/Natizyskunk/vscode-sftp/issues/125)
- [one file to n servers #156](https://github.com/Natizyskunk/vscode-sftp/issues/156)
- [upload local files to multiple servers at once. #127](https://github.com/Natizyskunk/vscode-sftp/issues/127)
- [Multiples profiles and multiples contexts #277](https://github.com/Natizyskunk/vscode-sftp/issues/277)

## new commands

- Upload File To All Profiles
- Upload Active File To All Profiles
- Upload Folder To All Profiles
- Upload Project To All Profiles
- Force Upload To All Profiles