### PR TITLE
Add filePerm and dirPerm options for configuring permissions

### DIFF
--- a/docs/common_configuration.md
+++ b/docs/common_configuration.md
@@ -33,6 +33,16 @@ Use this when you want to map a subfolder to the `remotePath`.
 
 **default**: `/`
 
+## filePerm
+*number*: Set octal file permissions for new files.
+
+**default**: false
+
+## dirPerm
+*number*: Set octal directory permissions for new directories.
+
+**default**: false
+
 ## uploadOnSave
 *boolean*: Upload on every save operation of VSCode.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,16 @@ Use this when you want to map a subfolder to the `remotePath`.
 
 **default**: `/`
 
+## filePerm
+*number*: Set octal file permissions for new files.
+
+**default**: false
+
+## dirPerm
+*number*: Set octal directory permissions for new directories.
+
+**default**: false
+
 ## uploadOnSave
 *boolean*: Upload on every save operation of VSCode.
 

--- a/src/core/fileService.ts
+++ b/src/core/fileService.ts
@@ -40,6 +40,8 @@ interface ServiceOption {
   useTempFile: boolean;
   openSsh: boolean;
   downloadOnOpen: boolean | 'confirm';
+  filePerm?: number;
+  dirPerm?: number;
   syncOption: {
     delete: boolean;
     skipCreate: boolean;

--- a/src/core/fs/fileSystem.ts
+++ b/src/core/fs/fileSystem.ts
@@ -77,6 +77,7 @@ export default abstract class FileSystem {
   abstract put(input: Readable, path, option?: FileOption): Promise<void>;
   abstract mkdir(dir: string): Promise<void>;
   abstract ensureDir(dir: string): Promise<void>;
+  abstract chmod(path: string, mode: number): Promise<void>;
   abstract list(dir: string, option?): Promise<FileEntry[]>;
   abstract lstat(path: string): Promise<FileStats>;
   abstract readlink(path: string): Promise<string>;

--- a/src/core/fs/localFileSystem.ts
+++ b/src/core/fs/localFileSystem.ts
@@ -70,6 +70,18 @@ export default class LocalFileSystem extends FileSystem {
     });
   }
 
+  async chmod(path: string, mode: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      fs.chmod(path, mode, (err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
   put(input: fs.ReadStream, path, option?: FileOption): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       if (option && option.fd && typeof option.fd !== 'number') {

--- a/src/core/fs/sftpFileSystem.ts
+++ b/src/core/fs/sftpFileSystem.ts
@@ -164,6 +164,18 @@ export default class SFTPFileSystem extends RemoteFileSystem {
     });
   }
 
+  async chmod(path: string, mode: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.sftp.chmod(path, mode, err => {
+        if(err) {
+          reject(err)
+          return
+        }
+        resolve();
+      });
+    })
+  }
+
   get(path, option?: FileOption): Promise<Readable> {
     return new Promise((resolve, reject) => {
       // const opt = { ...option, autoDestroy: false };

--- a/src/core/transferTask.ts
+++ b/src/core/transferTask.ts
@@ -20,6 +20,8 @@ export interface TransferOption {
   atime: number;
   mtime: number;
   mode?: number;
+  filePerm?: number;
+  dirPerm?: number;
   fallbackMode?: number;
   perserveTargetMode: boolean;
   useTempFile?: boolean;
@@ -122,8 +124,10 @@ export default class TransferTask implements Task {
       fallbackMode,
       atime,
       mtime,
+      filePerm
     } = this._TransferOption;
-    let { mode } = this._TransferOption;
+    // Set the mode if it's specified in the config, otherwise get mode from server.
+    let mode = filePerm ? parseInt(String(filePerm), 8) : this._TransferOption.mode;
     let targetFd; // Destination file
     let uploadFd; // Temp file or destination file when no temp file is used
     const uploadTarget = target + (useTempFile ? ".new" : "");

--- a/src/fileHandlers/transfer/index.ts
+++ b/src/fileHandlers/transfer/index.ts
@@ -26,6 +26,8 @@ function createTransferHandle(direction: TransferDirection) {
         targetFsPath: remoteFsPath,
         targetFs: remoteFs,
         transferOption: option,
+        filePerm: this.config.filePerm,
+        dirPerm: this.config.dirPerm,
         transferDirection: TransferDirection.LOCAL_TO_REMOTE,
       };
     }
@@ -45,6 +47,9 @@ export const sync2Remote = createFileHandler<SyncOption>({
     const localFs = this.fileService.getLocalFileSystem();
     const { localFsPath, remoteFsPath } = this.target;
     const scheduler = this.fileService.createTransferScheduler(this.config.concurrency);
+    // Attach filePerm and dirPerm to transferOption
+    option.filePerm = this.config.filePerm;
+    option.dirPerm = this.config.dirPerm;
     await sync(
       {
         srcFsPath: localFsPath,
@@ -62,7 +67,7 @@ export const sync2Remote = createFileHandler<SyncOption>({
     const config = this.config;
     const syncOption = config.syncOption || {};
     return {
-      perserveTargetMode: config.protocol === 'sftp',
+      perserveTargetMode: config.protocol === 'sftp' && !config.filePerm && !config.dirPerm,
       useTempFile: config.useTempFile,
       openSsh: config.openSsh,
       // remoteTimeOffsetInHours: config.remoteTimeOffsetInHours,
@@ -119,7 +124,7 @@ export const upload = createFileHandler<TransferOption>({
   transformOption() {
     const config = this.config;
     return {
-      perserveTargetMode: config.protocol === 'sftp',
+      perserveTargetMode: config.protocol === 'sftp' && !config.filePerm && !config.dirPerm,
       useTempFile: config.useTempFile,
       openSsh: config.openSsh,
       // remoteTimeOffsetInHours: config.remoteTimeOffsetInHours,
@@ -137,7 +142,7 @@ export const uploadFile = createFileHandler<TransferOption>({
   transformOption() {
     const config = this.config;
     return {
-      perserveTargetMode: config.protocol === 'sftp',
+      perserveTargetMode: config.protocol === 'sftp' && !config.filePerm,
       useTempFile: config.useTempFile,
       openSsh: config.openSsh,
       // remoteTimeOffsetInHours: config.remoteTimeOffsetInHours,
@@ -155,7 +160,7 @@ export const uploadFolder = createFileHandler<TransferOption>({
   transformOption() {
     const config = this.config;
     return {
-      perserveTargetMode: config.protocol === 'sftp',
+      perserveTargetMode: config.protocol === 'sftp' && !config.dirPerm,
       useTempFile: config.useTempFile,
       openSsh: config.openSsh,
       // remoteTimeOffsetInHours: config.remoteTimeOffsetInHours,


### PR DESCRIPTION
Hi, 

This PR adds directory and file permission options. 

In sftp.json if you set: 

"filePerm": 777,
"dirPerm": 777

For example, files and folders will be created with that permission set.

This should fix #174 
