### PR TITLE
Add ability to refresh the currently focused remote file

### DIFF
--- a/package.json
+++ b/package.json
@@ -283,6 +283,15 @@
           "light": "resources/light/refresh.svg",
           "dark": "resources/dark/refresh.svg"
         }
+      },
+      {
+        "command": "sftp.remoteExplorer.refreshActiveFile",
+        "title": "Refresh Active Remote File",
+        "category": "SFTP",
+        "icon": {
+          "light": "resources/light/refresh.svg",
+          "dark": "resources/dark/refresh.svg"
+        }
       }
     ],
     "menus": {
@@ -524,6 +533,13 @@
         {
           "command": "sftp.remoteExplorer.editInLocal",
           "group": "2_files",
+          "when": "sftp.enabled && resourceScheme == remote"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "sftp.remoteExplorer.refreshActiveFile",
+          "group": "navigation",
           "when": "sftp.enabled && resourceScheme == remote"
         }
       ],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,6 +58,7 @@ export const COMMAND_REVEAL_IN_EXPLORER = 'sftp.revealInExplorer';
 export const COMMAND_REVEAL_IN_REMOTE_EXPLORER = 'sftp.revealInRemoteExplorer';
 
 export const COMMAND_REMOTEEXPLORER_REFRESH = 'sftp.remoteExplorer.refresh';
+export const COMMAND_REMOTEEXPLORER_REFRESH_ACTIVE_FILE = "sftp.remoteExplorer.refreshActiveFile"
 export const COMMAND_REMOTEEXPLORER_EDITINLOCAL = 'sftp.remoteExplorer.editInLocal';
 export const COMMAND_REMOTEEXPLORER_VIEW_CONTENT = 'sftp.viewContent';
 

--- a/src/modules/remoteExplorer/explorer.ts
+++ b/src/modules/remoteExplorer/explorer.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { registerCommand } from '../../host';
 import {
   COMMAND_REMOTEEXPLORER_REFRESH,
+  COMMAND_REMOTEEXPLORER_REFRESH_ACTIVE_FILE,
   COMMAND_REMOTEEXPLORER_VIEW_CONTENT,
 } from '../../constants';
 import { UResource } from '../../core';
@@ -27,6 +28,7 @@ export default class RemoteExplorer {
     });
 
     registerCommand(context, COMMAND_REMOTEEXPLORER_REFRESH, () => this._refreshSelection());
+    registerCommand(context, COMMAND_REMOTEEXPLORER_REFRESH_ACTIVE_FILE, () => this._refreshActiveRemoteFile());
     registerCommand(context, COMMAND_REMOTEEXPLORER_VIEW_CONTENT, (item: ExplorerItem) =>
       this._treeDataProvider.showItem(item)
     );
@@ -73,5 +75,28 @@ export default class RemoteExplorer {
     } else {
       this.refresh();
     }
+  }
+
+  private _refreshActiveRemoteFile() {
+    const focusedEditor = vscode.window.activeTextEditor;
+    if (focusedEditor) {
+
+      const remoteFileUri = focusedEditor.document.uri;
+      const root = this._treeDataProvider.findRoot(remoteFileUri);
+      const incompleteResource = UResource.makeResource(remoteFileUri);
+
+      if (!root) {
+        return;
+      }
+      const remoteFileItem = {
+        resource: UResource.updateResource(root.resource, {
+          remotePath: incompleteResource.fsPath
+        }),
+        isDirectory: false
+      };
+
+      this.refresh(remoteFileItem);
+    }
+    
   }
 }


### PR DESCRIPTION
Added a command and a button in the file editor to refresh the focused remote file. This button only shows when viewing the preview from the remote file explorer. This differs from the refresh button in the remote file explorer as the remote file explorer button will refresh the active selected tree item. So you could open file1, open file2, then switch back to file1 by clicking the tab, and the refresh button in the remote file explorer would refresh file2. 