### PR TITLE
Fix ProxyJump support from SSH config

### DIFF
--- a/src/commands/commandOpenSshConnection.ts
+++ b/src/commands/commandOpenSshConnection.ts
@@ -25,10 +25,14 @@ function adaptPath(filepath) {
 }
 
 function getSshCommand(
-  config: { host: string; port: number; username: string },
+  config: { host: string; port: number; username: string; sshConfigPath?: string },
   extraOption?: string
 ) {
-  let sshStr = `ssh -t ${config.username}@${config.host} -p ${config.port}`;
+  let sshStr = 'ssh -t';
+  if (config.sshConfigPath) {
+    sshStr += ` -F "${adaptPath(config.sshConfigPath)}"`;
+  }
+  sshStr += ` ${config.username}@${config.host} -p ${config.port}`;
   if (extraOption) {
     sshStr += ` ${extraOption}`;
   }
@@ -75,9 +79,10 @@ export default checkCommand({
     }
 
     const sshConfig = {
-      host: remoteConfig.host,
+      host: remoteConfig.sshHostAlias || remoteConfig.host,
       port: remoteConfig.port,
       username: remoteConfig.username,
+      sshConfigPath: remoteConfig.sshConfigPath,
     };
     const terminal = vscode.window.createTerminal(remoteConfig.name);
     let sshCommand;

--- a/src/core/__tests__/fileService.ts
+++ b/src/core/__tests__/fileService.ts
@@ -1,0 +1,78 @@
+jest.mock('../../app', () => ({
+  __esModule: true,
+  default: {
+    fsCache: new Map(),
+    state: {
+      profile: null,
+    },
+  },
+}));
+
+jest.mock('../../logger', () => ({
+  __esModule: true,
+  default: {
+    trace: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    critical: jest.fn(),
+  },
+}));
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import FileService from '../fileService';
+
+describe('FileService ssh config integration', () => {
+  test('preserves ProxyJump when HostName is resolved from ssh config', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sftp-proxyjump-'));
+    const sshConfigPath = path.join(tempDir, 'ssh_config');
+
+    fs.writeFileSync(
+      sshConfigPath,
+      `
+Host target-alias
+  HostName target.internal
+  User root
+  Port 22
+  ProxyJump bastion
+  IdentityFile ~/.ssh/id_ed25519
+
+Host bastion
+  HostName bastion.example.com
+  User root
+  Port 2222
+  IdentityFile ~/.ssh/id_ed25519
+`
+    );
+
+    const service = new FileService(tempDir, tempDir, {
+      name: 'target-alias',
+      protocol: 'sftp',
+      host: 'target-alias',
+      remotePath: '/workspace/project',
+      uploadOnSave: true,
+      useTempFile: false,
+      ignore: [],
+      sshConfigPath,
+    } as any);
+
+    const config = service.getConfig();
+
+    expect(config.host).toBe('target.internal');
+    expect(config.port).toBe(22);
+    expect(config.username).toBe('root');
+    expect(config.sshHostAlias).toBe('target-alias');
+    expect(config.proxyJump).toEqual([
+      {
+        host: 'bastion.example.com',
+        port: 2222,
+        username: 'root',
+        privateKeyPath: `${os.homedir()}/.ssh/id_ed25519`,
+        connectTimeout: undefined,
+      },
+    ]);
+  });
+});

--- a/src/core/__tests__/sshConfigResolver.ts
+++ b/src/core/__tests__/sshConfigResolver.ts
@@ -1,0 +1,110 @@
+import * as os from 'os';
+import * as sshConfig from 'ssh-config';
+import {
+  resolveProxyJumpChain,
+  resolveSSHConfig,
+  splitProxyJump,
+} from '../sshConfigResolver';
+
+function parse(content: string) {
+  return sshConfig.parse(content);
+}
+
+describe('sshConfigResolver', () => {
+  test('splitProxyJump keeps hop order', () => {
+    expect(splitProxyJump('jump-a, jump-b ,jump-c')).toEqual([
+      'jump-a',
+      'jump-b',
+      'jump-c',
+    ]);
+  });
+
+  test('resolveSSHConfig includes proxy jump aliases from ssh config', () => {
+    const parsed = parse(`
+Host jump-a
+  HostName bastion.example.com
+  User root
+  IdentityFile ~/.ssh/jump_a
+
+Host target
+  HostName target.internal
+  User app
+  Port 2222
+  ProxyJump jump-a
+  IdentityFile ~/.ssh/target_key
+`);
+
+    const resolved = resolveSSHConfig(parsed as any, 'target');
+
+    expect(resolved.host).toBe('target.internal');
+    expect(resolved.username).toBe('app');
+    expect(resolved.port).toBe(2222);
+    expect(resolved.privateKeyPath).toBe(`${os.homedir()}/.ssh/target_key`);
+    expect(resolved.proxyJump).toEqual([
+      {
+        host: 'bastion.example.com',
+        port: undefined,
+        username: 'root',
+        privateKeyPath: `${os.homedir()}/.ssh/jump_a`,
+        connectTimeout: undefined,
+      },
+    ]);
+  });
+
+  test('resolveProxyJumpChain flattens nested proxy jumps', () => {
+    const parsed = parse(`
+Host edge
+  HostName edge.example.com
+
+Host mid
+  HostName mid.internal
+  ProxyJump edge
+
+Host target
+  HostName target.internal
+  ProxyJump mid
+`);
+
+    const resolved = resolveSSHConfig(parsed as any, 'target', {
+      privateKeyPath: '/tmp/shared-key',
+    });
+
+    expect(resolved.proxyJump).toEqual([
+      {
+        host: 'edge.example.com',
+        port: undefined,
+        username: undefined,
+        privateKeyPath: '/tmp/shared-key',
+        connectTimeout: undefined,
+      },
+      {
+        host: 'mid.internal',
+        port: undefined,
+        username: undefined,
+        privateKeyPath: '/tmp/shared-key',
+        connectTimeout: undefined,
+      },
+    ]);
+  });
+
+  test('resolveProxyJumpChain supports literal user host port specs', () => {
+    const parsed = parse(`
+Host target
+  HostName target.internal
+  ProxyJump root@bastion.example.com:2222
+`);
+
+    const chain = resolveProxyJumpChain(
+      parsed as any,
+      'root@bastion.example.com:2222'
+    );
+
+    expect(chain).toEqual([
+      {
+        host: 'bastion.example.com',
+        port: 2222,
+        username: 'root',
+      },
+    ]);
+  });
+});

--- a/src/core/fileService.ts
+++ b/src/core/fileService.ts
@@ -12,6 +12,7 @@ import Ignore from './ignore';
 import { FileSystem } from './fs';
 import Scheduler from './scheduler';
 import { createRemoteIfNoneExist, removeRemoteFs } from './remoteFs';
+import { resolveSSHConfig } from './sshConfigResolver';
 import TransferTask from './transferTask';
 import localFs from './localFs';
 
@@ -75,6 +76,8 @@ interface SftpOption {
   concurrency: number;
   sshCustomParams?: string;
   hop: (Host & SftpOption)[] | (Host & SftpOption);
+  proxyJump?: (Host & SftpOption)[];
+  sshHostAlias?: string;
 }
 
 interface FtpOption {
@@ -236,8 +239,9 @@ function mergeConfigWithExternalRefer(
   }
 
   const parsedSSHConfig = sshConfig.parse(sshConfigContent);
+  const sshLookupHost = copyed.host;
   const section = parsedSSHConfig.find({
-    Host: copyed.host,
+    Host: sshLookupHost,
   });
 
   if (section === null) {
@@ -250,7 +254,7 @@ function mergeConfigWithExternalRefer(
     ['user', 'username'],
     ['identityfile', 'privateKeyPath'],
     ['serveraliveinterval', 'keepalive'],
-    ['connecttimeout', 'connTimeout'],
+    ['connecttimeout', 'connectTimeout'],
   ]);
 
   section.config.forEach(line => {
@@ -268,6 +272,29 @@ function mergeConfigWithExternalRefer(
       }
     }
   });
+
+  const resolved = resolveSSHConfig(parsedSSHConfig as any, sshLookupHost, {
+    agent: copyed.agent,
+    privateKeyPath: copyed.privateKeyPath,
+    passphrase: copyed.passphrase,
+    interactiveAuth: copyed.interactiveAuth,
+    algorithms: copyed.algorithms,
+    connectTimeout: copyed.connectTimeout,
+  });
+
+  if (resolved.host) {
+    copyed.host = resolved.host;
+    copyed.sshHostAlias = config.host;
+  }
+
+  setConfigValue(copyed, 'port', resolved.port);
+  setConfigValue(copyed, 'username', resolved.username);
+  setConfigValue(copyed, 'privateKeyPath', resolved.privateKeyPath);
+  setConfigValue(copyed, 'connectTimeout', resolved.connectTimeout);
+
+  if (resolved.proxyJump && copyed.proxyJump === undefined) {
+    copyed.proxyJump = resolved.proxyJump as any;
+  }
 
   // Bug introduced in pull request #69 : Fix ssh config resolution
   /* const parsedSSHConfig = sshConfig.parse(sshConfigContent);
@@ -322,6 +349,16 @@ function getCompleteConfig(
       workspace,
       mergedConfig.privateKeyPath
     );
+  }
+
+  if (mergedConfig.proxyJump) {
+    mergedConfig.proxyJump = mergedConfig.proxyJump.map(jumpOption => {
+      const next = Object.assign({}, jumpOption);
+      if (next.privateKeyPath) {
+        next.privateKeyPath = resolvePath(workspace, next.privateKeyPath);
+      }
+      return next;
+    });
   }
 
   if (mergedConfig.ignoreFile) {

--- a/src/core/remote-client/__tests__/sshClient.ts
+++ b/src/core/remote-client/__tests__/sshClient.ts
@@ -1,0 +1,61 @@
+jest.mock('../../../logger', () => ({
+  __esModule: true,
+  default: {
+    trace: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    critical: jest.fn(),
+  },
+}));
+
+import SSHClient from '../sshClient';
+import localFs from '../../localFs';
+
+describe('SSHClient proxyJump', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('does not open sftp subsystems on proxy jump intermediates', async () => {
+    jest
+      .spyOn(localFs, 'readFile')
+      .mockImplementation(async () => Buffer.from('PRIVATE KEY'));
+
+    const connectSSHClient = jest
+      .spyOn(SSHClient.prototype as any, '_connectSSHClient')
+      .mockImplementation(async () => undefined);
+    const getSftp = jest
+      .spyOn(SSHClient.prototype as any, '_getSftp')
+      .mockResolvedValue({ readdir: jest.fn() });
+    const makeHopping = jest
+      .spyOn(SSHClient.prototype as any, '_makeHopping')
+      .mockImplementation(async () => ({ on() {}, once() {}, end() {} }));
+
+    const option: any = {
+      host: 'target.internal',
+      port: 22,
+      username: 'root',
+      privateKeyPath: '/tmp/target-key',
+      proxyJump: [
+        {
+          host: 'bastion.example.com',
+          port: 2222,
+          username: 'root',
+          privateKeyPath: '/tmp/jump-key',
+        },
+      ],
+      debug() {},
+    };
+
+    const client = new SSHClient(option);
+    await client.connect(option, {
+      askForPasswd: async () => undefined,
+    });
+
+    expect(connectSSHClient).toHaveBeenCalledTimes(2);
+    expect(makeHopping).toHaveBeenCalledTimes(1);
+    expect(getSftp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/remote-client/remoteClient.ts
+++ b/src/core/remote-client/remoteClient.ts
@@ -17,6 +17,7 @@ export interface ConnectOption {
   agent?: string;
   sock?: any;
   hop?: ConnectOption | ConnectOption[];
+  proxyJump?: ConnectOption[];
   limitOpenFilesOnRemote?: boolean | number;
 
   // ftp-only

--- a/src/core/remote-client/sshClient.ts
+++ b/src/core/remote-client/sshClient.ts
@@ -36,12 +36,49 @@ export default class SSHClient extends RemoteClient {
     connectOption: ConnectOption,
     config: Config
   ): Promise<void> {
-    const { hop, ...option } = connectOption;
+    const { hop, proxyJump, ...option } = connectOption;
 
     let lastOption: ConnectOption = option;
     let fs: FileSystem | RemoteFileSystem = localFs;
     let sock;
-    if (
+    if (Array.isArray(proxyJump) && proxyJump.length > 0) {
+      this.hoppingClients = [];
+
+      for (let index = 0; index < proxyJump.length; index++) {
+        const curOpt = Object.assign({}, proxyJump[index]);
+        if (curOpt.port === undefined) {
+          curOpt.port = 22;
+        }
+
+        const preClient = this.hoppingClients[index - 1];
+        if (preClient) {
+          sock = await this._makeHopping(preClient, curOpt.host, curOpt.port);
+        } else {
+          sock = undefined;
+        }
+
+        if (curOpt.privateKeyPath) {
+          const buffer = await localFs.readFile(curOpt.privateKeyPath);
+          curOpt.privateKey = buffer.toString();
+        }
+
+        const client = new SSHClient(curOpt);
+        this.hoppingClients.push(client);
+        await client._connectSSHClient(
+          client._client,
+          Object.assign({}, curOpt, { sock }),
+          config
+        );
+      }
+
+      const lastClient = this.hoppingClients[this.hoppingClients.length - 1];
+      sock = await this._makeHopping(
+        lastClient,
+        lastOption.host,
+        lastOption.port
+      );
+      fs = localFs;
+    } else if (
       (Array.isArray(hop) && hop.length > 0) ||
       (hop && Object.keys(hop).length > 0)
     ) {
@@ -337,7 +374,7 @@ export default class SSHClient extends RemoteClient {
       // Create a connect form 127.0.0.1:port to dstHost:dstPort
       sshClient._client.forwardOut(
         '127.0.0.1',
-        sshClient._option.port,
+        0,
         dstHost,
         dstPort,
         (error, stream) => {

--- a/src/core/remoteFs.ts
+++ b/src/core/remoteFs.ts
@@ -12,9 +12,26 @@ import {
 import localFs from './localFs';
 
 function hashOption(opiton) {
-  return Object.keys(opiton)
-    .map(key => opiton[key])
-    .join('');
+  const normalize = value => {
+    if (Array.isArray(value)) {
+      return value.map(normalize);
+    }
+
+    if (value && typeof value === 'object') {
+      return Object.keys(value)
+        .sort()
+        .reduce((result, key) => {
+          if (typeof value[key] !== 'function') {
+            result[key] = normalize(value[key]);
+          }
+          return result;
+        }, {});
+    }
+
+    return value;
+  };
+
+  return JSON.stringify(normalize(opiton));
 }
 
 class KeepAliveRemoteFs {

--- a/src/core/sshConfigResolver.ts
+++ b/src/core/sshConfigResolver.ts
@@ -1,0 +1,179 @@
+import * as os from 'os';
+
+interface SSHConfigLike {
+  find(query: { Host: string }): any;
+  compute(host: string): any;
+}
+
+interface JumpFallbackOption {
+  agent?: string;
+  privateKeyPath?: string;
+  passphrase?: string | boolean;
+  interactiveAuth?: boolean | string[];
+  algorithms?: any;
+  connectTimeout?: number;
+}
+
+interface ResolvedConnectionOption extends JumpFallbackOption {
+  host: string;
+  port?: number;
+  username?: string;
+  proxyJump?: ResolvedConnectionOption[];
+}
+
+function replaceHomePath(pathname: string) {
+  return pathname.substr(0, 2) === '~/' ? `${os.homedir()}/${pathname.slice(2)}` : pathname;
+}
+
+function parseInteger(value: any): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function firstIdentityFile(value: any): string | undefined {
+  if (Array.isArray(value)) {
+    return value.length > 0 ? replaceHomePath(value[0]) : undefined;
+  }
+
+  if (typeof value === 'string' && value.length > 0) {
+    return replaceHomePath(value);
+  }
+
+  return undefined;
+}
+
+function applyFallbacks(
+  option: ResolvedConnectionOption,
+  fallback: JumpFallbackOption
+): ResolvedConnectionOption {
+  const resolved = Object.assign({}, option);
+  const keys = [
+    'agent',
+    'privateKeyPath',
+    'passphrase',
+    'interactiveAuth',
+    'algorithms',
+    'connectTimeout',
+  ];
+
+  keys.forEach(key => {
+    if (resolved[key] === undefined && fallback[key] !== undefined) {
+      resolved[key] = fallback[key];
+    }
+  });
+
+  return resolved;
+}
+
+function parseProxyJumpSpec(spec: string): ResolvedConnectionOption {
+  const trimmed = spec.trim();
+  if (!trimmed) {
+    throw new Error('ProxyJump contains an empty host');
+  }
+
+  let username;
+  let hostPort = trimmed;
+  const atIndex = trimmed.lastIndexOf('@');
+  if (atIndex > 0) {
+    username = trimmed.slice(0, atIndex);
+    hostPort = trimmed.slice(atIndex + 1);
+  }
+
+  const lastColonIndex = hostPort.lastIndexOf(':');
+  const hasPort =
+    lastColonIndex > 0 &&
+    hostPort.indexOf(']') === -1 &&
+    hostPort.indexOf(':') === lastColonIndex;
+
+  let host = hostPort;
+  let port;
+  if (hasPort) {
+    host = hostPort.slice(0, lastColonIndex);
+    port = parseInteger(hostPort.slice(lastColonIndex + 1));
+  }
+
+  return {
+    host,
+    port,
+    username,
+  };
+}
+
+function mapComputedConfig(computed: any): ResolvedConnectionOption {
+  return {
+    host: computed.HostName || computed.Host,
+    port: parseInteger(computed.Port),
+    username: computed.User,
+    privateKeyPath: firstIdentityFile(computed.IdentityFile),
+    connectTimeout: parseInteger(computed.ConnectTimeout),
+  };
+}
+
+function resolveProxyJumpTarget(
+  parsedSSHConfig: SSHConfigLike,
+  spec: string,
+  fallback: JumpFallbackOption,
+  visited: Set<string>
+): ResolvedConnectionOption[] {
+  const found = parsedSSHConfig.find({ Host: spec });
+  if (found === null) {
+    return [applyFallbacks(parseProxyJumpSpec(spec), fallback)];
+  }
+
+  if (visited.has(spec)) {
+    throw new Error(`Circular ProxyJump detected for "${spec}"`);
+  }
+
+  const nextVisited = new Set(visited);
+  nextVisited.add(spec);
+
+  const computed = parsedSSHConfig.compute(spec);
+  const current = applyFallbacks(mapComputedConfig(computed), fallback);
+  const nested = computed.ProxyJump
+    ? resolveProxyJumpChain(parsedSSHConfig, computed.ProxyJump, fallback, nextVisited)
+    : [];
+
+  return nested.concat(current);
+}
+
+export function splitProxyJump(value: string): string[] {
+  return value
+    .split(',')
+    .map(x => x.trim())
+    .filter(Boolean);
+}
+
+export function resolveProxyJumpChain(
+  parsedSSHConfig: SSHConfigLike,
+  proxyJump: string,
+  fallback: JumpFallbackOption = {},
+  visited: Set<string> = new Set()
+): ResolvedConnectionOption[] {
+  return splitProxyJump(proxyJump).reduce<ResolvedConnectionOption[]>(
+    (result, spec) =>
+      result.concat(resolveProxyJumpTarget(parsedSSHConfig, spec, fallback, visited)),
+    []
+  );
+}
+
+export function resolveSSHConfig(
+  parsedSSHConfig: SSHConfigLike,
+  host: string,
+  fallback: JumpFallbackOption = {}
+): ResolvedConnectionOption {
+  const computed = parsedSSHConfig.compute(host);
+  const resolved = applyFallbacks(mapComputedConfig(computed), fallback);
+  if (computed.ProxyJump) {
+    resolved.proxyJump = resolveProxyJumpChain(
+      parsedSSHConfig,
+      computed.ProxyJump,
+      fallback,
+      new Set([host])
+    );
+  }
+  return resolved;
+}

--- a/test/preprocessor.js
+++ b/test/preprocessor.js
@@ -4,8 +4,10 @@ const tsConfig = require('../tsconfig.json');
 module.exports = {
   process(src, path) {
     if (path.endsWith('.ts')) {
-      return tsc.transpile(src, tsConfig.compilerOptions, path, []);
+      return {
+        code: tsc.transpile(src, tsConfig.compilerOptions, path, []),
+      };
     }
-    return src;
+    return { code: src };
   },
 };


### PR DESCRIPTION
## Summary

This PR improves SFTP connections for setups that rely on OpenSSH `ProxyJump` entries in `~/.ssh/config`.

It fixes two related issues:

1. `ProxyJump` was lost after resolving `HostName` from the SSH config.
2. Intermediate jump hosts were treated like regular SFTP targets and attempted to open an SFTP subsystem, which breaks bastion-only setups.

## What changed

- add SSH config resolution helpers for `ProxyJump`
- preserve the original SSH alias while resolving `HostName`
- carry resolved `proxyJump` connection options into the final SFTP config
- connect jump hosts as raw SSH hops instead of opening SFTP on each intermediate host
- normalize remote cache keys so nested connection options like `proxyJump` do not collide
- make `Open SSH in Terminal` prefer the original SSH alias and `sshConfigPath` when available
- update the Jest TypeScript preprocessor to match the current Jest transformer return shape
- add regression tests for:
  - resolving `ProxyJump` from SSH config
  - preserving `ProxyJump` after `HostName` resolution
  - avoiding SFTP subsystem creation on intermediate jump hosts

## Why

In a setup like:

```sshconfig
Host target-alias
    HostName target.internal
    User root
    ProxyJump jump-host
```

the extension resolved `HostName` first, then looked up the resolved host again, so `ProxyJump` was no longer available.

Even after carrying the jump information forward, the hop implementation still opened SFTP on the bastion host, which caused failures for bastions that only support forwarding.

## Validation

Tested with a real SSH config using a bastion + target chain.

Verified:
- SSH config resolves to the expected target host and jump chain
- SFTP can connect through the bastion and list the remote directory
- upload on save succeeds with a `ProxyJump` based host alias
- added Jest coverage for the resolution and hop behavior

Commands used:
- `npx jest src/core/__tests__/fileService.ts src/core/__tests__/sshConfigResolver.ts src/core/remote-client/__tests__/sshClient.ts --runInBand`
- `npm run compile`
