### PR TITLE
Deprecation handoff to CCD SFTP with user-first migration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # sftp sync extension for VS Code
 
+## Deprecation Notice
+
+**This extension is no longer actively maintained.**
+
+For continuity, this repository remains available as historical context for the community and previous contributors.
+
+### Recommended successor: CCD SFTP
+
+- Marketplace: https://marketplace.visualstudio.com/items?itemName=CCD-Studios.ccd-sftp
+- Repository: https://github.com/ChrisCurdDesign/vscode-sftp
+
+## Migration
+
+1. Uninstall old extension.
+2. Install `CCD-Studios.ccd-sftp`.
+3. Keep your existing `sftp.json` config unless specific settings changed.
+
+## Old readme:
+
 New maintained and updated version by [@Natizyskunk](https://github.com/Natizyskunk/) 😀 <!-- and [@satiromarra](https://github.com/satiromarra) --> <br>
 (Forked from the no longer maintained [liximomo's SFTP plugin](https://github.com/liximomo/vscode-sftp.git))
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,5 +1,12 @@
 # Home
 
+> This extension is no longer actively maintained.
+>
+> Recommended successor: **CCD SFTP**
+>
+> - Marketplace: https://marketplace.visualstudio.com/items?itemName=CCD-Studios.ccd-sftp
+> - Repository: https://github.com/ChrisCurdDesign/vscode-sftp
+
 1. [Setting](./setting.md)
 2. [Config](./configuration.md)
     - [Common](./common_configuration.md)


### PR DESCRIPTION
Hi @Natizyskunk, thanks for all your hard work on this plugin!

As it's no longer maintained, we decided to create a new fork and actively maintain it over at https://github.com/ChrisCurdDesign/vscode-sftp

We've made all the changes required to notify users of the deprecation, so if you're happy for us to take over, please run the following command to notify vscode of the replacement:

```
vcse deprecate satiromarra.sftp --replacement CCD-Studios.ccd-sftp
```

## Summary
Deprecates satiromarra.sftp in favor of CCD-Studios.ccd-sftp and updates docs so users have a clear, low-friction migration path.

## What Changed
- Added a prominent deprecation notice in README.
- Added successor links (Marketplace + repository).
- Added short migration steps:
  - Uninstall old extension
  - Install CCD-Studios.ccd-sftp
  - Keep existing sftp.json unless specific settings changed
- Added matching deprecation notice to docs home entry point.

## Why
Improves user clarity, preserves project continuity, and reduces ecosystem fragmentation by guiding users to the maintained successor.

## Note
The same replacement can also be configured in the Visual Studio Marketplace publisher portal.