### PR TITLE
Fix watcher uploading empty files during remote → local sync

### DIFF
--- a/src/core/fileService.ts
+++ b/src/core/fileService.ts
@@ -458,7 +458,6 @@ export default class FileService {
       concurrency,
     });
     scheduler.onTaskStart(task => {
-      this._pendingTransferTasks.add(task as TransferTask);
       this._eventEmitter.emit(Event.BEFORE_TRANSFER, task);
     });
     scheduler.onTaskDone((err, task) => {
@@ -481,6 +480,11 @@ export default class FileService {
           return;
         }
 
+        // Track the task from the moment it is queued rather than from the
+        // moment it starts. Only `concurrency` tasks run at a time, so
+        // consumers of getPendingTransferTasks() would otherwise be blind to
+        // every task still waiting in the queue.
+        fileService._pendingTransferTasks.add(task);
         scheduler.add(task);
       },
       run() {

--- a/src/core/transferTask.ts
+++ b/src/core/transferTask.ts
@@ -132,6 +132,11 @@ export default class TransferTask implements Task {
     let uploadFd; // Temp file or destination file when no temp file is used
     const uploadTarget = target + (useTempFile ? ".new" : "");
 
+    // Open the source before touching the destination. Opening the destination
+    // with 'w' truncates it, so opening both at once leaves an empty file
+    // behind whenever reading the source fails.
+    this._handle = await srcFs.get(src);
+
     // Use mode first.
     // Then check perserveTargetMode and fallback to fallbackMode if fail to get mode of target
     if (mode === undefined && perserveTargetMode) {
@@ -146,28 +151,21 @@ export default class TransferTask implements Task {
       }
 
       if (targetFd) {
-        [this._handle, mode] = await Promise.all([
-          srcFs.get(src),
-          targetFs
-            .fstat(targetFd)
-            .then(stat => stat.mode)
-            .catch(() => fallbackMode),
-        ]);
+        mode = await targetFs
+          .fstat(targetFd)
+          .then(stat => stat.mode)
+          .catch(() => fallbackMode);
 
         if (useTempFile) {
           targetFs.close(targetFd);
         }
 
       } else {
-        this._handle = await srcFs.get(src);
         mode = fallbackMode;
       }
 
     } else {
-      [this._handle, uploadFd] = await Promise.all([
-        srcFs.get(src),
-        targetFs.open(uploadTarget, 'w'),
-      ]);
+      uploadFd = await targetFs.open(uploadTarget, 'w');
     }
 
     try {

--- a/src/modules/fileWatcher.ts
+++ b/src/modules/fileWatcher.ts
@@ -12,14 +12,18 @@ const watchers: {
   [x: string]: vscode.FileSystemWatcher;
 } = {};
 
-const uploadQueue = new Set<vscode.Uri>();
-const deleteQueue = new Set<vscode.Uri>();
+// Keyed by fsPath. The watcher emits a new Uri instance per event, so a
+// Set<vscode.Uri> keeps one entry per event instead of one entry per file.
+const uploadQueue = new Map<string, vscode.Uri>();
+const deleteQueue = new Map<string, vscode.Uri>();
 
 // less than 550 will not work
 const ACTION_INTEVAL = 550;
 
 function doUpload() {
-  const files = Array.from(uploadQueue).sort((a, b) => fileDepth(b.fsPath) - fileDepth(a.fsPath));
+  const files = Array.from(uploadQueue.values()).sort(
+    (a, b) => fileDepth(b.fsPath) - fileDepth(a.fsPath)
+  );
   uploadQueue.clear();
 
   const currentDownloadTasks = getRunningTransformTasks().filter(
@@ -44,7 +48,9 @@ function doUpload() {
 }
 
 function doDelete() {
-  const files = Array.from(deleteQueue).sort((a, b) => fileDepth(b.fsPath) - fileDepth(a.fsPath));
+  const files = Array.from(deleteQueue.values()).sort(
+    (a, b) => fileDepth(b.fsPath) - fileDepth(a.fsPath)
+  );
   deleteQueue.clear();
   files.forEach(async uri => {
     const fspath = uri.fsPath;
@@ -66,7 +72,7 @@ function uploadHandler(uri: vscode.Uri) {
     return;
   }
 
-  uploadQueue.add(uri);
+  uploadQueue.set(uri.fsPath, uri);
   debouncedUpload();
 }
 
@@ -117,7 +123,7 @@ function createWatcher(
         return;
       }
 
-      deleteQueue.add(uri);
+      deleteQueue.set(uri.fsPath, uri);
       debouncedDelete();
     });
   }


### PR DESCRIPTION

**Description of the change**:

Stops a failed or queued download from being re-uploaded to the remote as an empty file.

**Reason for the change**:

With `watcher.autoUpload` on, **Sync Remote → Local** can overwrite files on the
*remote* with zero-byte files — including in the `"files": "**/*"` configuration
the FAQ recommends. Two defects combine:

`src/core/transferTask.ts` opens the destination with `'w'` (which truncates) in
the same `Promise.all` as the source read:

```ts
[this._handle, uploadFd] = await Promise.all([
  srcFs.get(src),
  targetFs.open(uploadTarget, 'w'),
]);
```

`Promise.all` rejects the moment `srcFs.get()` fails, but the `open(…, 'w')` it
started still lands — leaving the destination at 0 bytes and leaking `uploadFd`,
since the `finally` that closes it sits past the throw. This affects both
directions: the same path serves uploads, where a failed *local* read truncates
the **remote** file. Hoisting `srcFs.get(src)` above every
`targetFs.open(…, 'w')` means a failed read can no longer destroy the
destination. Costs one extra sequential round trip per file; the source open was
the expensive half anyway.

`fileWatcher.doUpload()` already skips files with an in-flight download, but
`src/core/fileService.ts` only populated `_pendingTransferTasks` in
`scheduler.onTaskStart`. With `concurrency` defaulting to 4, a several-hundred
file sync exposes at most 4 tasks to that guard and hides the rest. Tasks are now
registered when queued (`transferScheduler.add`) and still removed in
`onTaskDone`. `cancelTransferTasks()` already clears the set right after calling
`stop()` on every scheduler, so queued entries can't leak.

Third, smaller: `uploadQueue`/`deleteQueue` were `Set<vscode.Uri>`. The watcher
emits a new `Uri` instance per event and a `Set` dedupes by object identity, so
one file accumulated one entry per event and was uploaded that many times. Now
keyed by `fsPath`.

**Link to original source**:

https://github.com/Natizyskunk/vscode-sftp/issues/<issue#>

Closes #<issue#>

---

### Verification

- `npx tsc --noEmit` — 29 error lines on `master` and on this branch. Identical,
  none in the three touched files.
- `npx tslint -c tslint.json` on the three files — 8 errors on `master` and on
  this branch. Identical, all pre-existing (`quotemark`, `trailing-comma`).
- `npx jest` — 3 suites fail / 1 passes / 6 tests pass on both. Identical; the
  failures are a pre-existing Jest 28 incompatibility with
  `test/preprocessor.js`.
- Standalone repro of the truncation, before and after, in the linked issue.

Two things I'd rather flag than paper over:

1. **`npm run compile` fails on `master` at HEAD** — 5 errors, in
   `src/commands/abstract/createCommand.ts` (missing
   `COMMAND_UPLOAD_FILE_TO_ALL_PROFILES` /
   `COMMAND_UPLOAD_FOLDER_TO_ALL_PROFILES`) and `src/helper/paths.ts`
   (`vscode-uri` no longer exports `URI` as a named export). Reproduces with
   both `npm install` and `npm ci`, on files this PR doesn't touch, identically
   before and after the patch. Happy to open a separate PR — but it means I
   couldn't build a `.vsix`, so this change is verified by analysis and the
   standalone repro rather than by running a patched extension. Please weigh it
   accordingly.
2. **No test added.** The natural home is
   `src/fileHandlers/transfer/__tests__/`, but that suite doesn't currently run
   (see above). I'd rather not add a test that can't execute — glad to add one
   alongside a fix for the harness if you'd prefer.

### Docs

No user-facing behaviour or configuration change, so no README/FAQ update.
`watcher.autoUpload` keeps its current semantics.

---

## Which branch to push

`master` is 28 commits behind `develop`, so the original branch — cut from
`develop` — would carry 28 unrelated commits into a PR targeting `master`,
breaking the "squash all commits together" rule.

Two branches now exist locally, same diff, both a single commit:

| Branch | Base | Commits in PR | Use when |
|---|---|---|---|
| `fix-on-master` | `origin/master` | 1 | Targeting `master` — **what CONTRIBUTING says** |
| `fix-watcher-upload-during-download` | `origin/develop` | 1 | Only if a maintainer asks for `develop` |

The touched files are byte-identical on `master` and `develop`, so switching
base later is a cherry-pick, not a rework.

## CONTRIBUTING checklist

- [x] Title in `Add/Remove/Fix <feature>` format
- [x] Description ≤ 100 characters (88)
- [x] Short descriptive commit message
- [x] Searched previous issues and PRs — no duplicate (#513 and #342 are
      adjacent; no PR covers this)
- [x] All commits squashed (1 commit)
- [x] Targets `master`
- [x] Documentation considered — none needed, stated above
